### PR TITLE
Set references to PrivateAssets=None

### DIFF
--- a/src/Microsoft.AspNetCore/Microsoft.AspNetCore.csproj
+++ b/src/Microsoft.AspNetCore/Microsoft.AspNetCore.csproj
@@ -10,17 +10,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="1.2.0-*" />
-    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="1.2.0-*" />
-    <PackageReference Include="Microsoft.AspNetCore.Routing" Version="1.2.0-*" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="1.2.0-*" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="1.2.0-*" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="1.2.0-*" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="1.2.0-*" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.2.0-*" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.2.0-*" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.2.0-*" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="1.2.0-*" />
+    <!-- set PrivateAssets=None to ensure that all assets, including Build and Analyzer, are included in the nuspec -->
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="1.2.0-*" PrivateAssets="None" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="1.2.0-*" PrivateAssets="None" />
+    <PackageReference Include="Microsoft.AspNetCore.Routing" Version="1.2.0-*" PrivateAssets="None" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="1.2.0-*" PrivateAssets="None" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="1.2.0-*" PrivateAssets="None" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="1.2.0-*" PrivateAssets="None" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="1.2.0-*" PrivateAssets="None" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.2.0-*" PrivateAssets="None" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.2.0-*" PrivateAssets="None" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.2.0-*" PrivateAssets="None" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="1.2.0-*" PrivateAssets="None" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
By default, pack sets `PrivateAssets="Build,Analyzers"`, which means the metapackage would not import targets from any of the packages listed here.

Changes the generated nuspec from:
```xml
<dependency id="Microsoft.AspNetCore.Diagnostics" version="1.2.0-preview1-23373" exclude="Build,Analyzers" />
```
to
```xml
<dependency id="Microsoft.AspNetCore.Diagnostics" version="1.2.0-preview1-23373" include="All" />
```

None of them do...yet...but we'll need this for MvcPrecompliation.