### PR TITLE
Add target to set default target manifest

### DIFF
--- a/src/Microsoft.AspNetCore.All/Microsoft.AspNetCore.All.csproj
+++ b/src/Microsoft.AspNetCore.All/Microsoft.AspNetCore.All.csproj
@@ -146,4 +146,9 @@
     <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="$(AspNetCoreVersion)" PrivateAssets="None" Condition="'$(BUILD_PACKAGE_CACHE)' == 'true'" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="build\**\*.xml" Package="true" />
+    <Content Include="build\**\*.targets" Package="true" />
+  </ItemGroup>
+
 </Project>

--- a/src/Microsoft.AspNetCore.All/build/PublishWithAspNetCoreTargetManifest.targets
+++ b/src/Microsoft.AspNetCore.All/build/PublishWithAspNetCoreTargetManifest.targets
@@ -1,0 +1,48 @@
+<Project>
+
+  <PropertyGroup>
+    <PublishWithAspNetCoreTargetManifest Condition="'$(PublishWithAspNetCoreTargetManifest)'==''">true</PublishWithAspNetCoreTargetManifest>
+  </PropertyGroup>
+
+<!--
+*****************************************************************************
+Target: PublishWithAspNetCoreTargetManifest
+Append the default ASP.NET Core runtime package store manifest during publish
+*****************************************************************************
+-->
+  <Target
+    Name="PublishWithAspNetCoreTargetManifest"
+    BeforeTargets="Publish"
+    DependsOnTargets="PrepareForPublish"
+    Condition="'$(PublishWithAspNetCoreTargetManifest)'=='true' and '$(PublishableProject)'=='true'" >
+
+    <PropertyGroup>
+      <ManifestRuntimeIdentifier>$(AspNetCoreTargetManifestRuntimeIdentifier)</ManifestRuntimeIdentifier>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(AspNetCoreTargetManifestRuntimeIdentifier)'==''">
+      <ManifestRuntimeIdentifier
+        Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))'
+          and '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)'=='X64'">win7-x64</ManifestRuntimeIdentifier>
+      <ManifestRuntimeIdentifier
+        Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))'
+          and '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)'=='X86'">win7-x86</ManifestRuntimeIdentifier>
+      <ManifestRuntimeIdentifier
+        Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))'">osx.10.12-x64</ManifestRuntimeIdentifier>
+      <ManifestRuntimeIdentifier
+        Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))'">linux-x64</ManifestRuntimeIdentifier>
+    </PropertyGroup>
+
+    <Error
+      Text="Could not resolve manifest runtime identifier. Please specify the the runtime identifier via the AspNetCoreTargetManifestRuntimeIdentifier property."
+      Condition="'$(ManifestRuntimeIdentifier)'==''" />
+
+    <Message
+      Text="Appending default ASP.NET Core runtime package store manifest for use during publish based for the runtime $(ManifestRuntimeIdentifier)."
+      Importance="low" />
+
+    <PropertyGroup>
+      <TargetManifest>$(TargetManifest);$(MSBuildThisFileDirectory)manifest.$(ManifestRuntimeIdentifier).xml</TargetManifest>
+    </PropertyGroup>
+  </Target>
+</Project>

--- a/src/Microsoft.AspNetCore.All/build/netstandard1.6/Microsoft.AspNetCore.All.targets
+++ b/src/Microsoft.AspNetCore.All/build/netstandard1.6/Microsoft.AspNetCore.All.targets
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="$(MSBuildThisFileDirectory)..\PublishWithAspNetCoreTargetManifest.targets" />
+</Project>


### PR DESCRIPTION
#20 

Adding this target to set target manifest used before publish based on the current OS and Platform. The actual manifest.RID.xml will be added to this package during the build when it's generated by dotnet store. For cross-publish scenarios, `AspNetCoreTargetManifestRuntimeIdentifier` can be set in the project. `PublishWithAspNetCoreTargetManifest` can be set to false to publish without manifest.