### PR TITLE
Set TargetManifestFiles in PropertyGroup

### DIFF
--- a/src/Microsoft.AspNetCore.All/build/PublishWithAspNetCoreTargetManifest.targets
+++ b/src/Microsoft.AspNetCore.All/build/PublishWithAspNetCoreTargetManifest.targets
@@ -1,37 +1,37 @@
 <Project>
-
   <PropertyGroup>
     <PublishWithAspNetCoreTargetManifest Condition="'$(PublishWithAspNetCoreTargetManifest)'==''">true</PublishWithAspNetCoreTargetManifest>
+    <ManifestRuntimeIdentifier Condition="'$(PublishWithAspNetCoreTargetManifest)'=='true' and '$(PublishableProject)'=='true'" >$(AspNetCoreTargetManifestRuntimeIdentifier)</ManifestRuntimeIdentifier>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(PublishWithAspNetCoreTargetManifest)'=='true' and '$(PublishableProject)'=='true' and '$(ManifestRuntimeIdentifier)'==''">
+    <ManifestRuntimeIdentifier
+      Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))'
+        and '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)'=='X64'">win7-x64</ManifestRuntimeIdentifier>
+    <ManifestRuntimeIdentifier
+      Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))'
+        and '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)'=='X86'">win7-x86</ManifestRuntimeIdentifier>
+    <ManifestRuntimeIdentifier
+      Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))'">osx.10.12-x64</ManifestRuntimeIdentifier>
+    <ManifestRuntimeIdentifier
+      Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))'">linux-x64</ManifestRuntimeIdentifier>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(PublishWithAspNetCoreTargetManifest)'=='true' and '$(PublishableProject)'=='true'">
+    <TargetManifestFiles>$(TargetManifestFiles);$(MSBuildThisFileDirectory)manifest.$(ManifestRuntimeIdentifier).xml</TargetManifestFiles>
   </PropertyGroup>
 
 <!--
-*****************************************************************************
+*******************************************************
 Target: PublishWithAspNetCoreTargetManifest
-Append the default ASP.NET Core runtime package store manifest during publish
-*****************************************************************************
+Error if manifest runtime identifier cannot be resolved
+*******************************************************
 -->
   <Target
     Name="PublishWithAspNetCoreTargetManifest"
     BeforeTargets="Publish"
     DependsOnTargets="PrepareForPublish"
     Condition="'$(PublishWithAspNetCoreTargetManifest)'=='true' and '$(PublishableProject)'=='true'" >
-
-    <PropertyGroup>
-      <ManifestRuntimeIdentifier>$(AspNetCoreTargetManifestRuntimeIdentifier)</ManifestRuntimeIdentifier>
-    </PropertyGroup>
-
-    <PropertyGroup Condition="'$(AspNetCoreTargetManifestRuntimeIdentifier)'==''">
-      <ManifestRuntimeIdentifier
-        Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))'
-          and '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)'=='X64'">win7-x64</ManifestRuntimeIdentifier>
-      <ManifestRuntimeIdentifier
-        Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))'
-          and '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)'=='X86'">win7-x86</ManifestRuntimeIdentifier>
-      <ManifestRuntimeIdentifier
-        Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))'">osx.10.12-x64</ManifestRuntimeIdentifier>
-      <ManifestRuntimeIdentifier
-        Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))'">linux-x64</ManifestRuntimeIdentifier>
-    </PropertyGroup>
 
     <Error
       Text="Could not resolve manifest runtime identifier. Please specify the the runtime identifier via the AspNetCoreTargetManifestRuntimeIdentifier property."
@@ -40,9 +40,5 @@ Append the default ASP.NET Core runtime package store manifest during publish
     <Message
       Text="Appending default ASP.NET Core runtime package store manifest for use during publish based for the runtime $(ManifestRuntimeIdentifier)."
       Importance="low" />
-
-    <PropertyGroup>
-      <TargetManifest>$(TargetManifest);$(MSBuildThisFileDirectory)manifest.$(ManifestRuntimeIdentifier).xml</TargetManifest>
-    </PropertyGroup>
   </Target>
 </Project>


### PR DESCRIPTION
Fixes #50 

It's too late to set the `TargetManifestFiles` property inside a target that runs before publish. The dotnet sdk publish targets resolve the file list [here](https://github.com/dotnet/sdk/blob/39102ec214514363c6af4cd9d599a35aceb8c745/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Publish.targets#L32-L34). Since we don't rely on any other targets or properties to set `TargetManifestFiles`, the proposal in thiss PR sets the property in a property group before the donet sdk publish targets. Note that in this approach we no longer produce an error if the resolution of the manifest rid fails and will fail silently instead.

I tested on a local dotnet new console app with a package reference to M.A.All package and the publish output is trimmed.