### PR TITLE
Suppress failures to add user secrets

### DIFF
--- a/src/Microsoft.AspNetCore/WebHost.cs
+++ b/src/Microsoft.AspNetCore/WebHost.cs
@@ -159,10 +159,17 @@ namespace Microsoft.AspNetCore
 
                     if (env.IsDevelopment())
                     {
-                        var appAssembly = Assembly.Load(new AssemblyName(env.ApplicationName));
-                        if (appAssembly != null)
+                        try
                         {
-                            config.AddUserSecrets(appAssembly);
+                            var appAssembly = Assembly.Load(new AssemblyName(env.ApplicationName));
+                            if (appAssembly != null)
+                            {
+                                config.AddUserSecrets(appAssembly);
+                            }
+                        }
+                        catch
+                        {
+                            // silently fail if we cannot load the assembly or find the user secrets ID
                         }
                     }
 


### PR DESCRIPTION
Two things can go wrong:

1. Assembly.Load failures if env.ApplicationName does not correspond to a valid assembly
1. No UserSecretsIdAttribute on the assembly

Resolves #60 