### PR TITLE
Clean up before AddManifestToNupkg

### DIFF
--- a/build/repo.targets
+++ b/build/repo.targets
@@ -91,6 +91,7 @@
       <ManifestFiles Include="$(ArtifactsDir)*.xml"/>
     </ItemGroup>
 
+    <RemoveDir Directories="@(MetaPackageNupkg->'$(TempDir)%(Filename)')" />
     <Copy SourceFiles="@(MetaPackageNupkg)" DestinationFolder="$(ArtifactsDir)" />
     <UnzipArchive File="$(ArtifactsDir)%(MetaPackageNupkg.FileName)%(MetaPackageNupkg.Extension)" Destination="@(MetaPackageNupkg->'$(TempDir)%(Filename)')" />
     <Copy SourceFiles="@(ManifestFiles)" DestinationFolder="@(MetaPackageNupkg->'$(TempDir)%(Filename)\build\')" />


### PR DESCRIPTION
This fixes the rel/2.0.0-preivew1 build of Coherence-PackageCache