### PR TITLE
Add more packages

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -118,6 +118,7 @@
     <FullMetaPackagePackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="$(AspNetCoreVersion)" PrivateAssets="None" />
     <FullMetaPackagePackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions" Version="$(AspNetCoreVersion)" PrivateAssets="None" />
     <FullMetaPackagePackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv" Version="$(AspNetCoreVersion)" PrivateAssets="None" />
+    <FullMetaPackagePackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" Version="$(AspNetCoreVersion)" PrivateAssets="None" />
     <FullMetaPackagePackageReference Include="Microsoft.AspNetCore.Session" Version="$(AspNetCoreVersion)" PrivateAssets="None" />
     <FullMetaPackagePackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="$(AspNetCoreVersion)" PrivateAssets="None" />
     <FullMetaPackagePackageReference Include="Microsoft.AspNetCore.WebSockets" Version="$(AspNetCoreVersion)" PrivateAssets="None" />
@@ -135,6 +136,7 @@
     <FullMetaPackagePackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Design" Version="$(AspNetCoreVersion)" PrivateAssets="None" />
     <FullMetaPackagePackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="$(AspNetCoreVersion)" PrivateAssets="None" />
     <FullMetaPackagePackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.Design" Version="$(AspNetCoreVersion)" PrivateAssets="None" />
+    <FullMetaPackagePackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="$(AspNetCoreVersion)" PrivateAssets="None" />
     <FullMetaPackagePackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="$(AspNetCoreVersion)" PrivateAssets="None" />
     <FullMetaPackagePackageReference Include="Microsoft.Extensions.Caching.Memory" Version="$(AspNetCoreVersion)" PrivateAssets="None" />
     <FullMetaPackagePackageReference Include="Microsoft.Extensions.Caching.Redis" Version="$(AspNetCoreVersion)" PrivateAssets="None" />
@@ -165,6 +167,17 @@
     <FullMetaPackagePackageReference Include="Microsoft.Extensions.WebEncoders" Version="$(AspNetCoreVersion)" PrivateAssets="None" />
     <FullMetaPackagePackageReference Include="Microsoft.Net.Http.Headers" Version="$(AspNetCoreVersion)" PrivateAssets="None" />
     <FullMetaPackagePackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="$(AspNetCoreVersion)" PrivateAssets="None" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <FullMetaPackagePackageNoRuntimeStoreReference Include="Microsoft.VisualStudio.Web.CodeGeneration" Version="$(AspNetCoreVersion)" PrivateAssets="All" />
+    <FullMetaPackagePackageNoRuntimeStoreReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Contracts" Version="$(AspNetCoreVersion)" PrivateAssets="All" />
+    <FullMetaPackagePackageNoRuntimeStoreReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Core" Version="$(AspNetCoreVersion)" PrivateAssets="All" />
+    <FullMetaPackagePackageNoRuntimeStoreReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="$(AspNetCoreVersion)" PrivateAssets="All" />
+    <FullMetaPackagePackageNoRuntimeStoreReference Include="Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore" Version="$(AspNetCoreVersion)" PrivateAssets="All" />
+    <FullMetaPackagePackageNoRuntimeStoreReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Templating" Version="$(AspNetCoreVersion)" PrivateAssets="All" />
+    <FullMetaPackagePackageNoRuntimeStoreReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Utils" Version="$(AspNetCoreVersion)" PrivateAssets="All" />
+    <FullMetaPackagePackageNoRuntimeStoreReference Include="Microsoft.VisualStudio.Web.CodeGenerators.Mvc" Version="$(AspNetCoreVersion)" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.AspNetCore.All/Microsoft.AspNetCore.All.csproj
+++ b/src/Microsoft.AspNetCore.All/Microsoft.AspNetCore.All.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
    <PackageReference Include="@(FullMetaPackagePackageReference)" />
+   <PackageReference Include="@(FullMetaPackagePackageNoRuntimeStoreReference)" />
    <ProjectReference Include="@(FullMetaPackageProjectReference)" />
   </ItemGroup>
 


### PR DESCRIPTION
Addressing a few packages left behind in #21

Packages to add:

- [x] Microsoft.EntityFrameworCore.Tools,ship,exclude
- [x] Microsoft.VisualStudio.Web.CodeGeneration,ship,exclude
- [x] Microsoft.VisualStudio.Web.CodeGeneration.Contracts,ship,exclude
- [x] Microsoft.VisualStudio.Web.CodeGeneration.Core,ship,exclude
- [x] Microsoft.VisualStudio.Web.CodeGeneration.Design,ship,exclude
- [x] Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore,ship,exclude
- [x] Microsoft.VisualStudio.Web.CodeGeneration.Templating,ship,exclude
- [x] Microsoft.VisualStudio.Web.CodeGeneration.Utils,ship,exclude
- [x] Microsoft.VisualStudio.Web.CodeGenerators.Mvc,ship,exclude

The Scaffolding packages cannot be added right now due to https://github.com/dotnet/roslyn/issues/16040

