### PR TITLE
Hack a no timestamp version of the runtime store and deps file

### DIFF
--- a/build/repo.targets
+++ b/build/repo.targets
@@ -15,6 +15,8 @@
     <DepsOutputPath>$(MetaPackagePath)bin\deps\</DepsOutputPath>
     <ArtifactsDir>$(RepositoryRoot)artifacts\</ArtifactsDir>
     <ArtifactsZipDir>$(ArtifactsDir)zip\</ArtifactsZipDir>
+    <ArtifactsZipTimestampDir>$(ArtifactsZipDir)ts\</ArtifactsZipTimestampDir>
+    <ArtifactsZipNoTimestampDir>$(ArtifactsZipDir)nt\</ArtifactsZipNoTimestampDir>
     <TempDir>$(ArtifactsDir)temp\</TempDir>
     <ToolsDir>$(RepositoryRoot)tools\</ToolsDir>
     <DependencyBuildDirectory>$(RepositoryRoot).deps\build\</DependencyBuildDirectory>
@@ -47,7 +49,8 @@
       <OutputZipSufix Condition="'$(OSPlatform)' == 'Linux'">linux</OutputZipSufix>
       <OutputZipSufix Condition="'$(OSPlatform)' == 'macOS'">osx</OutputZipSufix>
 
-      <OutputZip>$(ArtifactsDir)Build.RS.$(OutputZipSufix).zip</OutputZip>
+      <OutputZip>$(ArtifactsDir)Build.RS.$(OutputZipSufix)-$(VersionSuffix).zip</OutputZip>
+      <OutputZipNoTimestamp>$(ArtifactsDir)Build.RS.$(OutputZipSufix).zip</OutputZipNoTimestamp>
     </PropertyGroup>
 
     <ItemGroup>
@@ -74,24 +77,43 @@
       <PackageStoreManifestFiles Include="$(PackageCacheOutputPath)%(RIDs.PlatformDir)\**\artifact.xml">
         <DestinationFile>manifest.%(RIDs.Identity).xml</DestinationFile>
       </PackageStoreManifestFiles>
-      <PackageCacheFiles Include="$(PackageCacheOutputPath)**\*" Exclude="$(PackageCacheOutputPath)**\artifact.xml" />
+      <_PackageCacheFiles Include="$(PackageCacheOutputPath)**\*" Exclude="$(PackageCacheOutputPath)**\artifact.xml" />
+      <PackageCacheFiles Include="@(_PackageCacheFiles)" >
+        <NoTimestampRecursiveDir>$([System.String]::new('%(RecursiveDir)').Replace('-$(BuildNumber)', '-final'))</NoTimestampRecursiveDir>
+      </PackageCacheFiles>
       <DepsFiles Include="$(DepsOutputPath)**\*" />
     </ItemGroup>
 
     <Move SourceFiles="%(PackageStoreManifestFiles.FullPath)" DestinationFiles="$(ArtifactsDir)%(PackageStoreManifestFiles.DestinationFile)" />
 
-    <Copy SourceFiles="@(PackageCacheFiles)" DestinationFolder="$(ArtifactsZipDir)store\%(RecursiveDir)" />
-    <Copy SourceFiles="@(DepsFiles)" DestinationFolder="$(ArtifactsZipDir)additionalDeps\%(RecursiveDir)" />
+    <Copy SourceFiles="@(DepsFiles)" DestinationFolder="$(ArtifactsZipTimestampDir)additionalDeps\%(RecursiveDir)" />
+    <Copy SourceFiles="@(PackageCacheFiles)" DestinationFolder="$(ArtifactsZipTimestampDir)store\%(RecursiveDir)" />
+    <Copy SourceFiles="@(DepsFiles)" DestinationFolder="$(ArtifactsZipNoTimestampDir)additionalDeps\%(RecursiveDir)" />
+    <Copy SourceFiles="@(PackageCacheFiles)" DestinationFiles="$(ArtifactsZipNoTimestampDir)store\%(PackageCacheFiles.NoTimestampRecursiveDir)%(PackageCacheFiles.FileName)%(PackageCacheFiles.Extension)" />
 
     <ItemGroup>
-      <OutputZipFiles Include="$(ArtifactsZipDir)**\*" />
+      <NoTimestampDepsFiles Include="$(ArtifactsZipNoTimestampDir)additionalDeps\**\*"/>
     </ItemGroup>
 
-    <ZipArchive File="$(OutputZip)" SourceFiles="@(OutputZipFiles)" WorkingDirectory="$(ArtifactsZipDir)" />
+    <MSBuild Projects="$(ProjectPath)" Targets="_RemoveTimestampFromDepsFile" Properties="DepsFile=%(NoTimestampDepsFiles.FullPath)" />
+
+    <ItemGroup>
+      <OutputZipFiles Include="$(ArtifactsZipTimestampDir)**\*" />
+      <OutputZipFilesNoTimestamp Include="$(ArtifactsZipNoTimestampDir)**\*" />
+    </ItemGroup>
+
+    <ZipArchive File="$(OutputZip)" SourceFiles="@(OutputZipFiles)" WorkingDirectory="$(ArtifactsZipTimestampDir)" />
+    <ZipArchive File="$(OutputZipNoTimeStamp)" SourceFiles="@(OutputZipFilesNoTimestamp)" WorkingDirectory="$(ArtifactsZipNoTimestampDir)" />
 
     <!--Drop a nuspec file in artifacts for packing zip files into a nupkg-->
     <Copy SourceFiles="$(RepositoryRoot)build\Build.RS.nuspec" DestinationFolder="$(ArtifactsDir)" Condition="'$(OSPlatform)'=='Windows'" />
     <WriteLinesToFile File="$(ArtifactsDir)version.txt" Lines="$(VersionPrefix)-$(VersionSuffix)" Overwrite="true" Condition="'$(OSPlatform)'=='Windows'" />
+  </Target>
+
+  <Target Name="_RemoveTimestampFromDepsFile">
+    <Exec Command="powershell.exe -command &quot;(Get-Content $(DepsFile)).replace('-$(BuildNumber)','-final') | Set-Content $(DepsFile)&quot;" Condition="'$(OSPlatform)'=='Windows'"/>
+    <Exec Command="sed -i '' -e &quot;s/\-$(BuildNumber)/\-final/g&quot; $(DepsFile)" Condition="'$(OSPlatform)'=='macOS'"/>
+    <Exec Command="sed -i -e &quot;s/\-$(BuildNumber)/\-final/g&quot; $(DepsFile)" Condition="'$(OSPlatform)'=='Linux'"/>
   </Target>
 
   <Target Name="_BuildFallbackArchive">


### PR DESCRIPTION
This looks so ugly. Especially when I have to shell out to ps/bash for search and replace since I didn't find a good way of doing it in MSBuild.