### PR TITLE
Build one zip per configuration

### DIFF
--- a/build/repo.targets
+++ b/build/repo.targets
@@ -24,13 +24,9 @@
       $(PrepareDependsOn);
       UpdateNuGetConfig
     </PrepareDependsOn>
-    <CompileDependsOn Condition="'$(BUILD_PACKAGE_CACHE)' == 'true'">
-      $(CompileDependsOn);
-      BuildPackageCache
-    </CompileDependsOn>
   </PropertyGroup>
 
-  <Target Name="UpdateNuGetConfig">
+  <Target Name="UpdateNuGetConfig" DependsOnTargets="UpdateNuGetConfig">
     <UpdatePackageSource
       NuGetConfigPath="$(RepositoryRoot)NuGet.config"
       SourceName="Dependencies"
@@ -45,37 +41,25 @@
     </GetOSPlatform>
 
     <PropertyGroup>
-      <OutputZipSufix Condition="'$(OSPlatform)' == 'Windows'">win</OutputZipSufix>
+      <OutputZipSufix Condition="'$(OSPlatform)' == 'Windows'">win$(PACKAGE_CACHE_PLATFORM)</OutputZipSufix>
       <OutputZipSufix Condition="'$(OSPlatform)' == 'Linux'">linux</OutputZipSufix>
       <OutputZipSufix Condition="'$(OSPlatform)' == 'macOS'">osx</OutputZipSufix>
+      <RID Condition="'$(OSPlatform)' == 'Windows'">win-$(PACKAGE_CACHE_PLATFORM)</RID>
+      <RID Condition="'$(OSPlatform)' == 'Linux'">linux-$(PACKAGE_CACHE_PLATFORM)</RID>
+      <RID Condition="'$(OSPlatform)' == 'macOS'">osx-$(PACKAGE_CACHE_PLATFORM)</RID>
 
       <OutputZip>$(ArtifactsDir)Build.RS.$(OutputZipSufix)-$(VersionSuffix).zip</OutputZip>
       <OutputZipNoTimestamp>$(ArtifactsDir)Build.RS.$(OutputZipSufix).zip</OutputZipNoTimestamp>
     </PropertyGroup>
 
-    <ItemGroup>
-      <RIDs Include="win7-x64" Condition="'$(OSPlatform)'=='Windows'" >
-        <PlatformDir>x64</PlatformDir>
-      </RIDs>
-      <RIDs Include="win7-x86" Condition="'$(OSPlatform)'=='Windows'" >
-        <PlatformDir>x86</PlatformDir>
-      </RIDs>
-      <RIDs Include="linux-x64" Condition="'$(OSPlatform)'=='Linux'" >
-        <PlatformDir>x64</PlatformDir>
-      </RIDs>
-      <RIDs Include="osx.10.12-x64" Condition="'$(OSPlatform)'=='macOS'" >
-        <PlatformDir>x64</PlatformDir>
-      </RIDs>
-    </ItemGroup>
-
     <RemoveDir Directories="$(PackageCacheOutputPath)" />
-    <RemoveDir Directories="$(WorkingDirectory)%(RIDs.Identity)\" />
-    <Exec Command="dotnet store --manifest $(MetaPackageFile) --configuration Release --framework netcoreapp2.0 --runtime %(RIDs.Identity) --output $(PackageCacheOutputPath) --framework-version 2.0.0-* --working-dir $(WorkingDirectory)%(RIDs.Identity)/" />
+    <RemoveDir Directories="$(WorkingDirectory)" />
+    <Exec Command="dotnet store --manifest $(MetaPackageFile) --configuration Release --framework netcoreapp2.0 --runtime $(RID) --output $(PackageCacheOutputPath) --framework-version 2.0.0-* --working-dir $(WorkingDirectory)" />
     <MsBuild Projects="$(MetaPackageFile)" Targets="CollectDeps" Properties="DepsOutputPath=$(DepsOutputPath)"/>
 
     <ItemGroup>
-      <PackageStoreManifestFiles Include="$(PackageCacheOutputPath)%(RIDs.PlatformDir)\**\artifact.xml">
-        <DestinationFile>manifest.%(RIDs.Identity).xml</DestinationFile>
+      <PackageStoreManifestFiles Include="$(PackageCacheOutputPath)**\artifact.xml">
+        <DestinationFile>manifest.$(RID).xml</DestinationFile>
       </PackageStoreManifestFiles>
       <_PackageCacheFiles Include="$(PackageCacheOutputPath)**\*" Exclude="$(PackageCacheOutputPath)**\artifact.xml" />
       <PackageCacheFiles Include="@(_PackageCacheFiles)" >
@@ -102,12 +86,12 @@
       <OutputZipFilesNoTimestamp Include="$(ArtifactsZipNoTimestampDir)**\*" />
     </ItemGroup>
 
-    <ZipArchive File="$(OutputZip)" SourceFiles="@(OutputZipFiles)" WorkingDirectory="$(ArtifactsZipTimestampDir)" />
-    <ZipArchive File="$(OutputZipNoTimeStamp)" SourceFiles="@(OutputZipFilesNoTimestamp)" WorkingDirectory="$(ArtifactsZipNoTimestampDir)" />
+    <ZipArchive File="$(OutputZip)" SourceFiles="@(OutputZipFiles)" WorkingDirectory="$(ArtifactsZipTimestampDir)" Overwrite="true"/>
+    <ZipArchive File="$(OutputZipNoTimeStamp)" SourceFiles="@(OutputZipFilesNoTimestamp)" WorkingDirectory="$(ArtifactsZipNoTimestampDir)" Overwrite="true"/>
 
     <!--Drop a nuspec file in artifacts for packing zip files into a nupkg-->
-    <Copy SourceFiles="$(RepositoryRoot)build\Build.RS.nuspec" DestinationFolder="$(ArtifactsDir)" Condition="'$(OSPlatform)'=='Windows'" />
-    <WriteLinesToFile File="$(ArtifactsDir)version.txt" Lines="$(VersionPrefix)-$(VersionSuffix)" Overwrite="true" Condition="'$(OSPlatform)'=='Windows'" />
+    <Copy SourceFiles="$(RepositoryRoot)build\Build.RS.nuspec" DestinationFolder="$(ArtifactsDir)" Condition="'$(OSPlatform)'=='Linux'" />
+    <WriteLinesToFile File="$(ArtifactsDir)version.txt" Lines="$(VersionPrefix)-$(VersionSuffix)" Overwrite="true" Condition="'$(OSPlatform)'=='Linux'" />
   </Target>
 
   <Target Name="_RemoveTimestampFromDepsFile">

--- a/src/Microsoft.AspNetCore.All/build/PublishWithAspNetCoreTargetManifest.targets
+++ b/src/Microsoft.AspNetCore.All/build/PublishWithAspNetCoreTargetManifest.targets
@@ -4,7 +4,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(PublishWithAspNetCoreTargetManifest)'=='true'">
-    <TargetManifestFiles>$(TargetManifestFiles);$(MSBuildThisFileDirectory)manifest.win7-x64.xml;$(MSBuildThisFileDirectory)manifest.win7-x86.xml;$(MSBuildThisFileDirectory)manifest.osx.10.12-x64.xml;$(MSBuildThisFileDirectory)manifest.linux-x64.xml</TargetManifestFiles>
+    <TargetManifestFiles>$(TargetManifestFiles);$(MSBuildThisFileDirectory)manifest.win-x64.xml;$(MSBuildThisFileDirectory)manifest.win-x86.xml;$(MSBuildThisFileDirectory)manifest.osx-x64.xml;$(MSBuildThisFileDirectory)manifest.linux-x64.xml</TargetManifestFiles>
   </PropertyGroup>
 
 <!--


### PR DESCRIPTION
Simplify the script to now build one runtime store per CI configuration. Also fix a few bugs and use the new consolidated RIDs.