### PR TITLE
Include tar.gz files in Build.RS nupkg

### DIFF
--- a/build/Build.RS.nuspec
+++ b/build/Build.RS.nuspec
@@ -8,5 +8,6 @@
   </metadata>
   <files>
     <file src="*.zip" target="" />
+    <file src="*.tar.gz" target="" />
   </files>
 </package>


### PR DESCRIPTION
After https://github.com/aspnet/Coherence-Signed/pull/478 we need to include .tar.gz files in the Build.RS nupkg. 

Note that this package is used mainly for testing with JitBench on x-plat. cc @rynowak This is not blocking installer work since they obtain the stores from the drop share.

cc @muratg to decide whether this should go into rel/2.0.0-preview1 or only dev. 