### PR TITLE
Minimal restore when building deps files

### DIFF
--- a/build/repo.targets
+++ b/build/repo.targets
@@ -37,7 +37,7 @@
       Condition="Exists('$(DependencyBuildDirectory)')" />
   </Target>
 
-  <Target Name="BuildPackageCache" DependsOnTargets="UpdateNuGetConfig;Restore">
+  <Target Name="BuildPackageCache" DependsOnTargets="UpdateNuGetConfig">
     <GetOSPlatform>
       <!-- Returns {Linux, macOS, Windows} -->
       <Output TaskParameter="PlatformName" PropertyName="OSPlatform" />
@@ -59,6 +59,7 @@
     <RemoveDir Directories="$(WorkingDirectory)" />
     <Exec Command="dotnet store --manifest $(MetaPackageFile) --configuration Release --framework netcoreapp2.0 --runtime $(RID) --output $(PackageCacheOutputPath) --framework-version 2.0.0-* --working-dir $(WorkingDirectory)" />
 
+    <Exec Command="dotnet restore" WorkingDirectory="$(RepositoryRoot)tools\TrimDeps" />
     <!--- MSBuild caches things if you run inproc so have to use Exec -->
     <Exec Command="dotnet msbuild /t:Restore;Rebuild;CollectDeps $(HostingStartupTemplateFile) /p:DepsOutputPath=$(DepsOutputPath);HostingStartupPackageName=%(HostingStartupPackageReference.Identity);HostingStartupPackageVersion=%(Version)"/>
 


### PR DESCRIPTION
This should fix the CI package cache build flakiness.

cc @kichalla @danroth27 