### PR TITLE
Use win7-x64/x86 rids for runtime store

### DIFF
--- a/build/repo.targets
+++ b/build/repo.targets
@@ -47,7 +47,7 @@
       <OutputZipSufix Condition="'$(OSPlatform)' == 'Windows'">win$(PACKAGE_CACHE_PLATFORM)</OutputZipSufix>
       <OutputZipSufix Condition="'$(OSPlatform)' == 'Linux'">linux</OutputZipSufix>
       <OutputZipSufix Condition="'$(OSPlatform)' == 'macOS'">osx</OutputZipSufix>
-      <RID Condition="'$(OSPlatform)' == 'Windows'">win-$(PACKAGE_CACHE_PLATFORM)</RID>
+      <RID Condition="'$(OSPlatform)' == 'Windows'">win7-$(PACKAGE_CACHE_PLATFORM)</RID>
       <RID Condition="'$(OSPlatform)' == 'Linux'">linux-$(PACKAGE_CACHE_PLATFORM)</RID>
       <RID Condition="'$(OSPlatform)' == 'macOS'">osx-$(PACKAGE_CACHE_PLATFORM)</RID>
 


### PR DESCRIPTION
We should be building the store witn win7-x64 and win7-x86 rids instead of win-x64 and win-x86 rids.

We should also verify that linux-x64 and osx-x64 are sufficient for the xplat runtime stores. It would be a dramatic change if we build one for each possible platform.

cc @DamianEdwards @davidfowl 