### PR TITLE
Fix generation of deps files on macOS and Linux

### DIFF
--- a/build/repo.targets
+++ b/build/repo.targets
@@ -63,7 +63,7 @@
     <Exec Command="dotnet restore" WorkingDirectory="$(HostingStartupTemplatePath)" />
 
     <!--- MSBuild caches things if you run inproc so have to use Exec -->
-    <Exec Command="dotnet msbuild /t:Restore;Rebuild;CollectDeps $(HostingStartupTemplateFile) /p:DepsOutputPath=$(DepsOutputPath);HostingStartupPackageName=%(HostingStartupPackageReference.Identity);HostingStartupPackageVersion=%(Version)"/>
+    <Exec Command="dotnet msbuild /t:&quot;Restore;Rebuild;CollectDeps&quot; $(HostingStartupTemplateFile) /p:&quot;DepsOutputPath=$(DepsOutputPath);HostingStartupPackageName=%(HostingStartupPackageReference.Identity);HostingStartupPackageVersion=%(Version)&quot;"/>
 
     <ItemGroup>
       <PackageStoreManifestFiles Include="$(PackageCacheOutputPath)**\artifact.xml">


### PR DESCRIPTION
On xplat we get the errors:
```
[22:16:02] :	 [Step 2/3]   /bin/sh: 2: /home/aspnetagent/buildAgent/temp/buildTmp/tmpa9c3d29b9bfb485898a17a111e61e096.exec.cmd: Rebuild: not found
[22:16:02] :	 [Step 2/3]   /bin/sh: 2: /home/aspnetagent/buildAgent/temp/buildTmp/tmpa9c3d29b9bfb485898a17a111e61e096.exec.cmd: CollectDeps: not found
```

Which means deps files are not generated. The next step then fails when we try to remove timestamps from those files.