### PR TITLE
Exclude build assets from sqlitepclraw and dependencies

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -164,16 +164,19 @@
     <FullMetaPackagePackageReference Include="Microsoft.AspNetCore.WebSockets" />
     <FullMetaPackagePackageReference Include="Microsoft.AspNetCore.WebUtilities" />
     <FullMetaPackagePackageReference Include="Microsoft.CodeAnalysis.Razor" />
-    <FullMetaPackagePackageReference Include="Microsoft.Data.Sqlite" />
+    <FullMetaPackagePackageReference Include="Microsoft.Data.Sqlite" PrivateAssets="Build" />
     <FullMetaPackagePackageReference Include="Microsoft.Data.Sqlite.Core" />
-     <!-- workaround for https://github.com/dotnet/sdk/issues/1166 and https://github.com/ericsink/SQLitePCL.raw/issues/157 -->
+    <!-- workaround for https://github.com/dotnet/sdk/issues/1166 and https://github.com/ericsink/SQLitePCL.raw/issues/157 -->
     <FullMetaPackagePackageReference Include="SQLitePCLRaw.bundle_green" Version="$(SQLitePCLRawVersion)" PrivateAssets="Build" />
+    <FullMetaPackagePackageReference Include="SQLitePCLRaw.lib.e_sqlite3.v110_xp" Version="$(SQLitePCLRawVersion)" PrivateAssets="Build" />
+    <FullMetaPackagePackageReference Include="SQLitePCLRaw.lib.e_sqlite3.linux" Version="$(SQLitePCLRawVersion)" PrivateAssets="Build" />
+    <FullMetaPackagePackageReference Include="SQLitePCLRaw.lib.e_sqlite3.osx" Version="$(SQLitePCLRawVersion)" PrivateAssets="Build" />
     <FullMetaPackagePackageReference Include="Microsoft.EntityFrameworkCore" />
     <FullMetaPackagePackageReference Include="Microsoft.EntityFrameworkCore.Design" />
     <FullMetaPackagePackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
     <FullMetaPackagePackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
     <FullMetaPackagePackageReference Include="Microsoft.EntityFrameworkCore.Relational.Design" />
-    <FullMetaPackagePackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+    <FullMetaPackagePackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" PrivateAssets="Build" />
     <FullMetaPackagePackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" />
     <FullMetaPackagePackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Design" />
     <FullMetaPackagePackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />


### PR DESCRIPTION
Per https://github.com/NuGet/Home/issues/5233, we need to mark everything that transitively depends on sqlitepclraw as PrivateAssets="Build". I took a look a the EF packages and it seems like they don't have any build assets them selves so this should be safe. I have verified that this workaround works and the sqlite native binaries no longer shows up in the publish output. Will need to update buildtools with the new third-party dependencies.

There is discussion with regards to whether the changes in https://github.com/dotnet/sdk/pull/1133 will be changed and the net461 PackageTargetFallback removed so this may no longer be relevant. However, in the meantime, we can use this workaround to trim the publish output.