### PR TITLE
Fix command line args not working when using CreateDefaultBuilder

### DIFF
--- a/src/Microsoft.AspNetCore/WebHost.cs
+++ b/src/Microsoft.AspNetCore/WebHost.cs
@@ -169,11 +169,6 @@ namespace Microsoft.AspNetCore
                     }
 
                     config.AddEnvironmentVariables();
-
-                    if (args != null)
-                    {
-                        config.AddCommandLine(args);
-                    }
                 })
                 .ConfigureLogging((hostingContext, logging) =>
                 {
@@ -190,6 +185,11 @@ namespace Microsoft.AspNetCore
                 {
                     services.AddTransient<IConfigureOptions<KestrelServerOptions>, KestrelServerOptionsSetup>();
                 });
+
+            if (args != null)
+            {
+                builder.ConfigureAppConfiguration((context, config) => config.AddCommandLine(args));
+            }
 
             return builder;
         }


### PR DESCRIPTION
This PR is to fix command line args not working when using `WebHost.CreateDefaultBuilder(args)`.

For example, when run `dotnet run --urls http://*:8003` with `WebHost.CreateDefaultBuilder(args)`, Kestrel server is still listening on port 5000.