### PR TITLE
Target NETStandard2.0

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -21,8 +21,8 @@
     <PackageReference Include="Internal.AspNetCore.Sdk" Version="$(InternalAspNetCoreSdkVersion)" PrivateAssets="All" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)'=='.NETFramework' AND '$(OutputType)'=='library'">
-    <PackageReference Include="NETStandard.Library" Version="$(BundledNETStandardPackageVersion)" />
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
+    <PackageReference Include="NETStandard.Library.NETFramework" Version="$(NETStandardLibraryNETFrameworkVersion)" PrivateAssets="All" />
   </ItemGroup>
 
   <!-- defines the default values for each item type -->

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -2,10 +2,10 @@
   <PropertyGroup>
     <AspNetCoreIntegrationTestingVersion>0.4.0-*</AspNetCoreIntegrationTestingVersion>
     <AspNetCoreVersion>2.0.0-*</AspNetCoreVersion>
-    <CoreFxVersion>4.3.0</CoreFxVersion>
+    <CoreFxVersion>4.4.0-*</CoreFxVersion>
     <InternalAspNetCoreSdkVersion>2.1.0-*</InternalAspNetCoreSdkVersion>
     <MoqVersion>4.7.1</MoqVersion>
-    <NETStandardImplicitPackageVersion>$(BundledNETStandardPackageVersion)</NETStandardImplicitPackageVersion>
+    <NETStandardLibraryNETFrameworkVersion>2.0.0-*</NETStandardLibraryNETFrameworkVersion>
     <NewtonsoftJsonVersion>10.0.1</NewtonsoftJsonVersion>
     <RuntimeFrameworkVersion Condition="'$(TargetFramework)'=='netcoreapp2.0'">2.0.0-*</RuntimeFrameworkVersion>
     <SQLitePCLRawVersion>1.1.5</SQLitePCLRawVersion>

--- a/samples/SampleApp/SampleApp.csproj
+++ b/samples/SampleApp/SampleApp.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\build\dependencies.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
     <UserSecretsId>aspnetcore-MetaPackagesSampleApp-20170406180413</UserSecretsId>
   </PropertyGroup>
 
@@ -16,4 +16,7 @@
     <ProjectReference Include="..\..\src\Microsoft.AspNetCore\Microsoft.AspNetCore.csproj" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
+    <PackageReference Include="NETStandard.Library.NETFramework" Version="$(NETStandardLibraryNETFrameworkVersion)" />
+  </ItemGroup>
 </Project>

--- a/src/Microsoft.AspNetCore/CertificateLoader.cs
+++ b/src/Microsoft.AspNetCore/CertificateLoader.cs
@@ -179,7 +179,13 @@ namespace Microsoft.AspNetCore
             {
                 var certificate = TryLoad(X509KeyStorageFlags.DefaultKeySet, out var error)
                     ?? TryLoad(X509KeyStorageFlags.UserKeySet, out error)
-                    ?? TryLoad(X509KeyStorageFlags.EphemeralKeySet, out error);
+#if NETCOREAPP2_0
+                    ?? TryLoad(X509KeyStorageFlags.EphemeralKeySet, out error)
+#elif NET461
+#else
+#error target frameworks need to be updated
+#endif
+                    ;
 
                 if (error != null)
                 {

--- a/src/Microsoft.AspNetCore/Microsoft.AspNetCore.csproj
+++ b/src/Microsoft.AspNetCore/Microsoft.AspNetCore.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
     <PackageTags>aspnetcore</PackageTags>
     <Description>Microsoft.AspNetCore</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Microsoft.DotNet.Archive/Microsoft.DotNet.Archive.csproj
+++ b/src/Microsoft.DotNet.Archive/Microsoft.DotNet.Archive.csproj
@@ -7,8 +7,4 @@
     <EnableApiCheck>false</EnableApiCheck>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="System.Linq.Parallel" Version="$(CoreFxVersion)" />
-  </ItemGroup>
-
 </Project>

--- a/test/Microsoft.AspNetCore.FunctionalTests/Microsoft.AspNetCore.FunctionalTests.csproj
+++ b/test/Microsoft.AspNetCore.FunctionalTests/Microsoft.AspNetCore.FunctionalTests.csproj
@@ -3,7 +3,15 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
+
+    <!--
+      Workaround for "Use executable flags in Microsoft.NET.Test.Sdk" (https://github.com/Microsoft/vstest/issues/792).
+      Remove when fixed.
+    -->
+    <HasRuntimeOutput>true</HasRuntimeOutput>
+    <RuntimeIdentifier Condition="'$(TargetFramework)' != 'netcoreapp2.0'">win7-x64</RuntimeIdentifier>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.AspNetCore.Tests/Microsoft.AspNetCore.Tests.csproj
+++ b/test/Microsoft.AspNetCore.Tests/Microsoft.AspNetCore.Tests.csproj
@@ -3,11 +3,12 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Microsoft.AspNetCore.All\Microsoft.AspNetCore.All.csproj" />
+    <ProjectReference Include="..\..\src\Microsoft.AspNetCore\Microsoft.AspNetCore.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Note a few caveats in this repo is a bit different. 

The only package we need to convert to NStandard2.0 is Microsoft.AspNetCore. M.A.All stays as netcoreapp2.0. 
The tests are a little misleading since there are functional and unit tests in the FunctionalTest project. I've added the net461 TFM to the FuntionalTests so that the unit tests are tested on both platforms. I'll file a follow up issue to split the functional and unit tests and also add coverage for .NET Framework variations for the functional tests.