### PR TITLE
Skip symbol generation during runtime store creation

### DIFF
--- a/build/repo.targets
+++ b/build/repo.targets
@@ -66,7 +66,7 @@
 
     <RemoveDir Directories="$(PackageCacheOutputPath)" />
     <RemoveDir Directories="$(WorkingDirectory)" />
-    <Exec Command="dotnet store --manifest $(MetaPackageFile) --framework netcoreapp2.0 --runtime $(RID) --output $(PackageCacheOutputPath) --framework-version 2.0.0-* --working-dir $(WorkingDirectory)" />
+    <Exec Command="dotnet store --manifest $(MetaPackageFile) --framework netcoreapp2.0 --runtime $(RID) --output $(PackageCacheOutputPath) --framework-version 2.0.0-* --working-dir $(WorkingDirectory) --skip-symbols" />
 
     <Exec Command="dotnet restore" WorkingDirectory="$(RepositoryRoot)tools\TrimDeps" />
     <Exec Command="dotnet restore" WorkingDirectory="$(HostingStartupTemplatePath)" />


### PR DESCRIPTION
Currently I see the error

```
Unable to load Microsoft.DiaSymReader.Native.amd64.dll.  Please ensure that Microsoft.DiaSymReader.Native.amd64.dll is on the path.  Error='126'
Error generating PDB for 'C:\gh\MetaPackages2\src\Microsoft.AspNetCore.RuntimeStore\bin\work\Build.RuntimeStore.References_2.0.0-preview2--\runtimopt\SQLitePCLRaw.core.dll': The specified module could not be found. (Exception from HRESULT: 0x8007007E)
```

when running dotnet store. This will unblock the build until I figure out what is going on.

cc @mikeharder @ryanbrandenburg 