### PR TITLE
Use file globbing to resolve manifests

### DIFF
--- a/src/Microsoft.AspNetCore.All/Microsoft.AspNetCore.All.csproj
+++ b/src/Microsoft.AspNetCore.All/Microsoft.AspNetCore.All.csproj
@@ -22,13 +22,4 @@
     <Content Include="build\**\*.targets" PackagePath="%(Identity)" />
   </ItemGroup>
 
-  <Target Name="UpdateManifestVersionNumbers" BeforeTargets="GenerateNuspec">
-    <PropertyGroup>
-      <ManifestTargetsFile>$(MSBuildThisFileDirectory)build\PublishWithAspNetCoreTargetManifest.targets</ManifestTargetsFile>
-    </PropertyGroup>
-
-    <Exec Command="powershell.exe -command &quot;(Get-Content $(ManifestTargetsFile)).replace('__MANIFEST_VERSION__','$(VersionPrefix)-$(VersionSuffix)') | Set-Content $(ManifestTargetsFile)&quot;" Condition="'$(OS)' == 'Windows_NT'"/>
-    <Exec Command="sed -i -e &quot;s/__MANIFEST_VERSION__/$(VersionPrefix)-$(VersionSuffix)/g&quot; $(ManifestTargetsFile)" Condition="'$(OS)' != 'Windows_NT'"/>
-  </Target>
-
 </Project>

--- a/src/Microsoft.AspNetCore.All/build/PublishWithAspNetCoreTargetManifest.targets
+++ b/src/Microsoft.AspNetCore.All/build/PublishWithAspNetCoreTargetManifest.targets
@@ -11,8 +11,7 @@ Error if PublishWithAspNetCoreTargetManifest is set to true for standalone app
 -->
   <Target
     Name="PublishWithAspNetCoreTargetManifest"
-    BeforeTargets="Publish"
-    DependsOnTargets="PrepareForPublish"
+    AfterTargets="PrepareForPublish"
     Condition="'$(PublishWithAspNetCoreTargetManifest)'=='true'" >
 
     <Error

--- a/src/Microsoft.AspNetCore.All/build/PublishWithAspNetCoreTargetManifest.targets
+++ b/src/Microsoft.AspNetCore.All/build/PublishWithAspNetCoreTargetManifest.targets
@@ -3,10 +3,6 @@
     <PublishWithAspNetCoreTargetManifest Condition="'$(PublishWithAspNetCoreTargetManifest)'=='' and '$(RuntimeIdentifier)'=='' and '$(RuntimeIdentifiers)'=='' and '$(PublishableProject)'=='true'">true</PublishWithAspNetCoreTargetManifest>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(PublishWithAspNetCoreTargetManifest)'=='true'">
-    <TargetManifestFiles>$(TargetManifestFiles);$(MSBuildThisFileDirectory)aspnetcore-store-__MANIFEST_VERSION__-win7-x64.xml;$(MSBuildThisFileDirectory)aspnetcore-store-__MANIFEST_VERSION__-win7-x86.xml;$(MSBuildThisFileDirectory)aspnetcore-store-__MANIFEST_VERSION__-osx-x64.xml;$(MSBuildThisFileDirectory)aspnetcore-store-__MANIFEST_VERSION__-linux-x64.xml</TargetManifestFiles>
-  </PropertyGroup>
-
 <!--
 ******************************************************************************
 Target: PublishWithAspNetCoreTargetManifest
@@ -22,5 +18,13 @@ Error if PublishWithAspNetCoreTargetManifest is set to true for standalone app
     <Error
       Text="PublishWithAspNetCoreTargetManifest cannot be set to true for standalone apps."
       Condition="'$(RuntimeIdentifier)'!='' or '$(RuntimeIdentifiers)'!=''" />
+
+    <ItemGroup>
+      <AspNetCoreTargetManifestFiles Include="$(MSBuildThisFileDirectory)aspnetcore-store-*.xml"/>
+    </ItemGroup>
+
+    <PropertyGroup>
+      <TargetManifestFiles>$(TargetManifestFiles);@(AspNetCoreTargetManifestFiles)</TargetManifestFiles>
+    </PropertyGroup>
   </Target>
 </Project>


### PR DESCRIPTION
Following up to https://github.com/aspnet/MetaPackages/pull/127.

Now that we have an updated CLI with the changes we needed, we can at least use file globbing to resolve the manifest names. This can go into preview2 but is also not necessary. 