### PR TITLE
Fix PackageCache builds

### DIFF
--- a/build/repo.targets
+++ b/build/repo.targets
@@ -93,7 +93,7 @@
     <RemoveDir Directories="$(RuntimeStoreOutputPath)" />
     <RemoveDir Directories="$(RuntimeStoreWorkingDirectory)" />
 
-    <Exec Command="dotnet store -m $(MetaPackageFile) -f netcoreapp2.0 -r $(RID) -o $(RuntimeStoreOutputPath) --framework-version 2.0.0-* -w $(RuntimeStoreWorkingDirectory)" />
+    <Exec Command="dotnet store -m $(MetaPackageFile) -f netcoreapp2.0 -r $(RID) -o $(RuntimeStoreOutputPath) --framework-version 2.0.0-* -w $(RuntimeStoreWorkingDirectory) $(RUNTIME_STORE_ADDITIONAL_ARGUMENTS)" />
 
     <!-- Create deps files for hosting startup -->
     <Exec Command="dotnet restore" WorkingDirectory="$(RepositoryRoot)tools\TrimDeps" />
@@ -141,18 +141,18 @@
 
     <ZipArchive File="$(OutputZip)" SourceFiles="@(OutputZipFiles)" WorkingDirectory="$(RuntimeStoreZipTimestampDir)" Overwrite="true"/>
     <ZipArchive File="$(OutputZipNoTimeStamp)" SourceFiles="@(OutputZipFilesNoTimestamp)" WorkingDirectory="$(RuntimeStoreZipNoTimestampDir)" Overwrite="true"/>
-    <ZipArchive File="$(OutputSymbolZip)" SourceFiles="@(OutputSymbolZipFiles)" WorkingDirectory="$(RuntimeStoreSymbolsZipTimestampDir)" Overwrite="true"/>
-    <ZipArchive File="$(OutputSymbolZipNoTimeStamp)" SourceFiles="@(OutputSymbolZipFilesNoTimestamp)" WorkingDirectory="$(RuntimeStoreSymbolsZipNoTimestampDir)" Overwrite="true"/>
+    <ZipArchive File="$(OutputSymbolZip)" SourceFiles="@(OutputSymbolZipFiles)" WorkingDirectory="$(RuntimeStoreSymbolsZipTimestampDir)" Overwrite="true" Condition="'$(OSPlatform)' != 'macOS'"/>
+    <ZipArchive File="$(OutputSymbolZipNoTimeStamp)" SourceFiles="@(OutputSymbolZipFilesNoTimestamp)" WorkingDirectory="$(RuntimeStoreSymbolsZipNoTimestampDir)" Overwrite="true" Condition="'$(OSPlatform)' != 'macOS'"/>
 
-    <MSBuild Projects="$(ProjectPath)" Targets="ConvertZipToTGZ" Properties="ZipFileName=$(OutputSymbolZip);TGZFileName=$(OutputSymbolTGZ)" />
-    <MSBuild Projects="$(ProjectPath)" Targets="ConvertZipToTGZ" Properties="ZipFileName=$(OutputSymbolZipNoTimeStamp);TGZFileName=$(OutputSymbolTGZNoTimeStamp)" />
+    <MSBuild Projects="$(ProjectPath)" Targets="ConvertZipToTGZ" Properties="ZipFileName=$(OutputSymbolZip);TGZFileName=$(OutputSymbolTGZ)" Condition="'$(OSPlatform)' == 'Linux'"/>
+    <MSBuild Projects="$(ProjectPath)" Targets="ConvertZipToTGZ" Properties="ZipFileName=$(OutputSymbolZipNoTimeStamp);TGZFileName=$(OutputSymbolTGZNoTimeStamp)" Condition="'$(OSPlatform)' == 'Linux'"/>
 
     <!--Drop a nuspec file in artifacts for packing zip files into a nupkg-->
     <Copy SourceFiles="$(RepositoryRoot)build\Build.RS.nuspec" DestinationFolder="$(ArtifactsDir)" Condition="'$(OSPlatform)'=='Linux'" />
     <WriteLinesToFile File="$(ArtifactsDir)version.txt" Lines="$(VersionPrefix)-$(VersionSuffix)" Overwrite="true" Condition="'$(OSPlatform)'=='Linux'" />
   </Target>
 
-  <Target Name="ConvertZipToTGZ" Condition="'$(OS)' != 'Windows_NT'">
+  <Target Name="ConvertZipToTGZ">
     <Exec Command="&quot;$(ToolsDir)zip2tgz.sh&quot; &quot;$(ZipFileName)&quot; &quot;$(TGZFileName)&quot;" />
     <Delete Files="$(ZipFileName)" />
   </Target>


### PR DESCRIPTION
No symbols are generated for macOS

Add environment variable to pass additional arguments to dotnet store