### PR TITLE
Even shorter notation to build and run a Webhosts

### DIFF
--- a/src/Microsoft.AspNetCore/WebHost.cs
+++ b/src/Microsoft.AspNetCore/WebHost.cs
@@ -191,5 +191,40 @@ namespace Microsoft.AspNetCore
 
             return builder;
         }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WebHostBuilder"/> class with pre-configured defaults using typed Startup
+        /// </summary>
+        /// <typeparam name="T">Specify the startup type to be used by the web host.</typeparam>
+        /// <param name="args">The command line args.</param>
+        /// <remarks>
+        ///   The following defaults are applied to the returned <see cref="WebHostBuilder"/>:
+        ///     use Kestrel as the web server,
+        ///     set the <see cref="IHostingEnvironment.ContentRootPath"/> to the result of <see cref="Directory.GetCurrentDirectory()"/>,
+        ///     load <see cref="IConfiguration"/> from 'appsettings.json' and 'appsettings.[<see cref="IHostingEnvironment.EnvironmentName"/>].json',
+        ///     load <see cref="IConfiguration"/> from User Secrets when <see cref="IHostingEnvironment.EnvironmentName"/> is 'Development' using the entry assembly,
+        ///     load <see cref="IConfiguration"/> from environment variables,
+        ///     configures the <see cref="ILoggerFactory"/> to log to the console and debug output,
+        ///     enables IIS integration,
+        ///     enables the ability for frameworks to bind their options to their default configuration sections,
+        ///     adds the developer exception page when <see cref="IHostingEnvironment.EnvironmentName"/> is 'Development'
+        ///     and sets the startup class as the typed defined in T.
+        /// </remarks>
+        /// <returns>The initialized <see cref="IWebHostBuilder"/>.</returns>
+        public static IWebHostBuilder CreateDefaultBuilder<T>(string[] args) where T : class
+        {
+            return WebHost.CreateDefaultBuilder(args)
+                .UseStartup<T>();
+        }
+
+        /// <summary>
+        /// Builds an Microsoft.AspNetCore.Hosting.IWebHost which hosts a web application and
+        /// runs a web application and block the calling thread until host shutdown.
+        /// </summary>
+        /// <param name="builder">The <see cref="IWebHostBuilder"/></param>
+        public static void BuildAndRun(this IWebHostBuilder builder)
+        {
+            builder.Build().Run();
+        }
     }
 }

--- a/test/TestSites/CreateDefaultBuilderApp/Program.cs
+++ b/test/TestSites/CreateDefaultBuilderApp/Program.cs
@@ -36,6 +36,11 @@ namespace CreateDefaultBuilderApp
                     });
                 })
                 .Build().Run();
+
+            Console.ReadKey();
+            WebHost.CreateDefaultBuilder<Startup>(new[] { "--cliKey", "cliValue" })
+                .BuildAndRun();
+
         }
 
         private static string GetResponseMessage(WebHostBuilderContext context, IServiceCollection services)

--- a/test/TestSites/CreateDefaultBuilderApp/Startup.cs
+++ b/test/TestSites/CreateDefaultBuilderApp/Startup.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+
+namespace CreateDefaultBuilderApp
+{
+    public class Startup
+    {
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        {
+            app.Run(async (context) =>
+            {
+                await context.Response.WriteAsync("Hello World!");
+            });
+        }
+    }
+}


### PR DESCRIPTION
Added support for allowing a shorthand notation to build and run a Webhost with the default configuration including a typed Startup class