### PR TITLE
Remove scaffolding packages

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -47,11 +47,6 @@
     <FullMetaPackageProjectReference>
       <PrivateAssets>None</PrivateAssets>
     </FullMetaPackageProjectReference>
-    <!-- set PrivateAssets=All to ensure items are excluded from the runtime store -->
-    <FullMetaPackagePackageNoRuntimeStoreReference>
-      <Version>$(AspNetCoreVersion)</Version>
-      <PrivateAssets>All</PrivateAssets>
-    </FullMetaPackagePackageNoRuntimeStoreReference>
   </ItemDefinitionGroup>
 
   <ItemGroup>
@@ -204,17 +199,6 @@
     <FullMetaPackagePackageReference Include="Microsoft.Extensions.WebEncoders" />
     <FullMetaPackagePackageReference Include="Microsoft.Net.Http.Headers" />
     <FullMetaPackagePackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <FullMetaPackagePackageNoRuntimeStoreReference Include="Microsoft.VisualStudio.Web.CodeGeneration" />
-    <FullMetaPackagePackageNoRuntimeStoreReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Contracts" />
-    <FullMetaPackagePackageNoRuntimeStoreReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Core" />
-    <FullMetaPackagePackageNoRuntimeStoreReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" />
-    <FullMetaPackagePackageNoRuntimeStoreReference Include="Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore" />
-    <FullMetaPackagePackageNoRuntimeStoreReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Templating" />
-    <FullMetaPackagePackageNoRuntimeStoreReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Utils" />
-    <FullMetaPackagePackageNoRuntimeStoreReference Include="Microsoft.VisualStudio.Web.CodeGenerators.Mvc" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Resolves most restore warnings about Microsoft.Composition. (There is still one coming from Archive.AspNetCore.All)

These references were essentially a no-op because they are not in the final Microsoft.AspNetCore.All package and are not in the runtime store.

cc @mikeharder @prafullbhosale