### PR TITLE
Remove SQLitePCLRaw workaround

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -152,11 +152,6 @@
     <FullMetaPackagePackageReference Include="Microsoft.CodeAnalysis.Razor" />
     <FullMetaPackagePackageReference Include="Microsoft.Data.Sqlite" PrivateAssets="Build" />
     <FullMetaPackagePackageReference Include="Microsoft.Data.Sqlite.Core" />
-    <!-- workaround for https://github.com/dotnet/sdk/issues/1166 and https://github.com/ericsink/SQLitePCL.raw/issues/157 -->
-    <FullMetaPackagePackageReference Include="SQLitePCLRaw.bundle_green" Version="$(SQLitePCLRawVersion)" PrivateAssets="Build" />
-    <FullMetaPackagePackageReference Include="SQLitePCLRaw.lib.e_sqlite3.v110_xp" Version="$(SQLitePCLRawVersion)" PrivateAssets="Build" />
-    <FullMetaPackagePackageReference Include="SQLitePCLRaw.lib.e_sqlite3.linux" Version="$(SQLitePCLRawVersion)" PrivateAssets="Build" />
-    <FullMetaPackagePackageReference Include="SQLitePCLRaw.lib.e_sqlite3.osx" Version="$(SQLitePCLRawVersion)" PrivateAssets="Build" />
     <FullMetaPackagePackageReference Include="Microsoft.EntityFrameworkCore" />
     <FullMetaPackagePackageReference Include="Microsoft.EntityFrameworkCore.Design" />
     <FullMetaPackagePackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -9,7 +9,6 @@
     <NETStandardLibraryNETFrameworkVersion>2.0.0-*</NETStandardLibraryNETFrameworkVersion>
     <NewtonsoftJsonVersion>10.0.1</NewtonsoftJsonVersion>
     <RuntimeFrameworkVersion Condition="'$(TargetFramework)'=='netcoreapp2.0'">2.0.0-*</RuntimeFrameworkVersion>
-    <SQLitePCLRawVersion>1.1.3</SQLitePCLRawVersion>
     <TestSdkVersion>15.3.0-*</TestSdkVersion>
     <XunitVersion>2.3.0-beta2-*</XunitVersion>
   </PropertyGroup>


### PR DESCRIPTION
No longer required with SQLitePCLRaw 1.1.6.

See https://github.com/aspnet/Microsoft.Data.Sqlite/pull/375 and https://github.com/aspnet/EntityFramework/pull/8890