### PR TITLE
Remove ViewCompilation from publish manifest

### DIFF
--- a/build/repo.targets
+++ b/build/repo.targets
@@ -166,6 +166,9 @@
     <!--Drop a nuspec file in artifacts for packing zip files into a nupkg-->
     <Copy SourceFiles="$(RepositoryRoot)build\Build.RS.nuspec" DestinationFolder="$(ArtifactsDir)" Condition="'$(OSPlatform)'=='Linux'" />
     <WriteLinesToFile File="$(ArtifactsDir)version.txt" Lines="$(VersionPrefix)-$(VersionSuffix)" Overwrite="true" Condition="'$(OSPlatform)'=='Linux'" />
+
+    <!-- Preview 2 Workaround: remove Microsoft.AspNetCore.Mvc.Razor.ViewCompilation from publish manifest -->
+    <Exec Command="sed -i -e '/microsoft.aspnetcore.mvc.razor.viewcompilation/d' $(ArtifactsDir)%(PackageStoreManifestFiles.TimestampDestinationFile)" Condition="'$(OS)' != 'Windows_NT'" />
   </Target>
 
   <Target Name="ConvertZipToTGZ">

--- a/src/Microsoft.AspNetCore.All/Microsoft.AspNetCore.All.csproj
+++ b/src/Microsoft.AspNetCore.All/Microsoft.AspNetCore.All.csproj
@@ -22,13 +22,4 @@
     <Content Include="build\**\*.targets" PackagePath="%(Identity)" />
   </ItemGroup>
 
-  <Target Name="UpdateManifestVersionNumbers" BeforeTargets="GenerateNuspec">
-    <PropertyGroup>
-      <ManifestTargetsFile>$(MSBuildThisFileDirectory)build\PublishWithAspNetCoreTargetManifest.targets</ManifestTargetsFile>
-    </PropertyGroup>
-
-    <Exec Command="powershell.exe -command &quot;(Get-Content $(ManifestTargetsFile)).replace('__MANIFEST_VERSION__','$(VersionPrefix)-$(VersionSuffix)') | Set-Content $(ManifestTargetsFile)&quot;" Condition="'$(OS)' == 'Windows_NT'"/>
-    <Exec Command="sed -i -e &quot;s/__MANIFEST_VERSION__/$(VersionPrefix)-$(VersionSuffix)/g&quot; $(ManifestTargetsFile)" Condition="'$(OS)' != 'Windows_NT'"/>
-  </Target>
-
 </Project>

--- a/src/Microsoft.AspNetCore.All/build/PublishWithAspNetCoreTargetManifest.targets
+++ b/src/Microsoft.AspNetCore.All/build/PublishWithAspNetCoreTargetManifest.targets
@@ -3,10 +3,6 @@
     <PublishWithAspNetCoreTargetManifest Condition="'$(PublishWithAspNetCoreTargetManifest)'=='' and '$(RuntimeIdentifier)'=='' and '$(RuntimeIdentifiers)'=='' and '$(PublishableProject)'=='true'">true</PublishWithAspNetCoreTargetManifest>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(PublishWithAspNetCoreTargetManifest)'=='true'">
-    <TargetManifestFiles>$(TargetManifestFiles);$(MSBuildThisFileDirectory)aspnetcore-store-__MANIFEST_VERSION__-win7-x64.xml;$(MSBuildThisFileDirectory)aspnetcore-store-__MANIFEST_VERSION__-win7-x86.xml;$(MSBuildThisFileDirectory)aspnetcore-store-__MANIFEST_VERSION__-osx-x64.xml;$(MSBuildThisFileDirectory)aspnetcore-store-__MANIFEST_VERSION__-linux-x64.xml</TargetManifestFiles>
-  </PropertyGroup>
-
 <!--
 ******************************************************************************
 Target: PublishWithAspNetCoreTargetManifest
@@ -15,12 +11,19 @@ Error if PublishWithAspNetCoreTargetManifest is set to true for standalone app
 -->
   <Target
     Name="PublishWithAspNetCoreTargetManifest"
-    BeforeTargets="Publish"
-    DependsOnTargets="PrepareForPublish"
+    AfterTargets="PrepareForPublish"
     Condition="'$(PublishWithAspNetCoreTargetManifest)'=='true'" >
 
     <Error
       Text="PublishWithAspNetCoreTargetManifest cannot be set to true for standalone apps."
       Condition="'$(RuntimeIdentifier)'!='' or '$(RuntimeIdentifiers)'!=''" />
+
+    <ItemGroup>
+      <AspNetCoreTargetManifestFiles Include="$(MSBuildThisFileDirectory)aspnetcore-store-*.xml"/>
+    </ItemGroup>
+
+    <PropertyGroup>
+      <TargetManifestFiles>$(TargetManifestFiles);@(AspNetCoreTargetManifestFiles)</TargetManifestFiles>
+    </PropertyGroup>
   </Target>
 </Project>


### PR DESCRIPTION
We are running into an issue where the store generated on windows and non-windows are different. The windows stores (x86 and x64) do not contain the M.A.Mvc.Razor.ViewCompilation while the non windows store (macOS and linux) do not. Our assumption that the stores on all platforms are the same is now broken so our approach of trimming by all manifests no longer works. We need to react accordingly in the M.A.All metapackage target and the proposal is to remove the ViewCompilation entry from the manifest so it will never be trimmed.

This would resolve https://github.com/aspnet/MvcPrecompilation/issues/146, note that after preview2 we plan to remove ViewCompilation from the runtime store so this will not be an issue for the next release.

I also ported the fix from https://github.com/aspnet/MetaPackages/pull/143, this helps us  resolve https://github.com/aspnet/MetaPackages/issues/161 without having to manually update the target file in the M.A.All package.