### PR TITLE
Set license to Apache 2.0

### DIFF
--- a/build/repo.targets
+++ b/build/repo.targets
@@ -381,7 +381,7 @@
       <InstallerMaintainerName>Microsoft</InstallerMaintainerName>
       <InstallerMaintainerEmail>nugetaspnet@microsoft.com</InstallerMaintainerEmail>
       <InstallerVendor>.NET Foundation</InstallerVendor>
-      <InstallerLicense>Apache</InstallerLicense>
+      <InstallerLicense>Apache-2.0</InstallerLicense>
       <InstallerPackageRevision>1</InstallerPackageRevision>
       <InstallerHomepage>https://www.asp.net/</InstallerHomepage>
       <InstallerInstallRoot>/usr/share/dotnet</InstallerInstallRoot>

--- a/tools/debian_config.json
+++ b/tools/debian_config.json
@@ -24,7 +24,7 @@
 
     "copyright": "Microsoft",
     "license": {
-        "type": "Apache",
+        "type": "Apache-2.0",
         "full_text": "Copyright (c) .NET Foundation. All rights reserved.\n\nLicensed under the Apache License, Version 2.0 (the \"License\"); you may not use\nthese files except in compliance with the License. You may obtain a copy of the\nLicense at\n\nhttp://www.apache.org/licenses/LICENSE-2.0\n\nUnless required by applicable law or agreed to in writing, software distributed\nunder the License is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR\nCONDITIONS OF ANY KIND, either express or implied. See the License for the\nspecific language governing permissions and limitations under the License."
     }
 }


### PR DESCRIPTION
As per discussion in https://github.com/aspnet/MetaPackages/pull/163#discussion_r123053769. This seems to be the more appropriate value for the license field since there is no other field to specify the version of the Apache license and the common licenses lists this specific value.