### PR TITLE
Use new SelfContained property

### DIFF
--- a/src/Microsoft.AspNetCore.All/build/PublishWithAspNetCoreTargetManifest.targets
+++ b/src/Microsoft.AspNetCore.All/build/PublishWithAspNetCoreTargetManifest.targets
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <PublishWithAspNetCoreTargetManifest Condition="'$(PublishWithAspNetCoreTargetManifest)'=='' and '$(RuntimeIdentifier)'=='' and '$(RuntimeIdentifiers)'=='' and '$(PublishableProject)'=='true'">true</PublishWithAspNetCoreTargetManifest>
+    <PublishWithAspNetCoreTargetManifest Condition="'$(PublishWithAspNetCoreTargetManifest)'=='' and '$(SelfContained)'=='false' and '$(PublishableProject)'=='true'">true</PublishWithAspNetCoreTargetManifest>
   </PropertyGroup>
 
 <!--
@@ -15,8 +15,8 @@ Error if PublishWithAspNetCoreTargetManifest is set to true for standalone app
     Condition="'$(PublishWithAspNetCoreTargetManifest)'=='true'" >
 
     <Error
-      Text="PublishWithAspNetCoreTargetManifest cannot be set to true for standalone apps."
-      Condition="'$(RuntimeIdentifier)'!='' or '$(RuntimeIdentifiers)'!=''" />
+      Text="PublishWithAspNetCoreTargetManifest cannot be set to true for self contained apps."
+      Condition="'$(SelfContained)'=='true'" />
 
     <ItemGroup>
       <AspNetCoreTargetManifestFiles Include="$(MSBuildThisFileDirectory)aspnetcore-store-*.xml"/>


### PR DESCRIPTION
Addresses https://github.com/aspnet/MetaPackages/issues/175. 

We will inspect this property instead of RuntimeIdentifier/RuntimeIdentifiers to determine whether the TargetManifestFiles should be updated. This new property is set in the sdk: https://github.com/dotnet/sdk/blob/43090565482d9a10481ff2298fb168fc819fa430/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.RuntimeIdentifierInference.targets#L107-L110

Still needs to be tested before being reviewed.