### PR TITLE
Workaround issue caused by importing Internal.AspNetCore.Sdk into repo.targets

### DIFF
--- a/build/repo.targets
+++ b/build/repo.targets
@@ -1,6 +1,11 @@
 <Project>
   <Import Project="common.props" />
 
+  <ItemGroup>
+    <!-- remove package references that don't belong in KoreBuild -->
+    <PackageReference Remove="Internal.AspNetCore.Sdk" />
+  </ItemGroup>
+
   <PropertyGroup>
     <!-- Project for building the Runtime Store -->
     <MetaPackagePath>$(RepositoryRoot)src\Microsoft.AspNetCore.RuntimeStore\</MetaPackagePath>


### PR DESCRIPTION
Internal.AspnetCore.Sdk should only be used in \*.csproj files, not repo.targets. Because repo.targets imports common.props, it ends up with a reference with this package, which is causing build failures due to changes in Internal.AspNetCore.BuildTools.Tasks.