### PR TITLE
Ensure Microsoft.AspNetCore.All is only compatible with netcoreapp2.0

### DIFF
--- a/src/Microsoft.AspNetCore.All/Microsoft.AspNetCore.All.csproj
+++ b/src/Microsoft.AspNetCore.All/Microsoft.AspNetCore.All.csproj
@@ -20,6 +20,7 @@
   <ItemGroup>
     <Content Include="build\**\*.xml" PackagePath="%(Identity)" />
     <Content Include="build\**\*.targets" PackagePath="%(Identity)" />
+    <Content Include="lib\$(TargetFramework)\_._" PackagePath="%(Identity)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Resolves #142 

When installing to net461, it will be incompatible:

![image](https://user-images.githubusercontent.com/2696087/27613569-1c3d7bae-5b51-11e7-83a0-b0994f88d5a7.png)
