### PR TITLE
Set "TreatWarningsAsErrors" before NuGet restore

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -12,6 +12,7 @@
     <PublicSign Condition="'$(OS)' != 'Windows_NT'">true</PublicSign>
     <OriginalVersionSuffix>$(VersionSuffix)</OriginalVersionSuffix>
     <VersionSuffix Condition="'$(BuildNumber)' != ''">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
     <!-- Pin versions to work around CLI bug -->
     <AspNetCoreVersion Condition="'$(BUILD_PACKAGE_CACHE)' == 'true'">2.0.0-$(VersionSuffix)</AspNetCoreVersion>


### PR DESCRIPTION
* Ensures our build stays clean of NuGet warnings