### PR TITLE
Pin runtime version for generated deps files

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -3,6 +3,7 @@
     <AspNetCoreIntegrationTestingVersion>0.4.0-*</AspNetCoreIntegrationTestingVersion>
     <AspNetCoreVersion>2.0.0-*</AspNetCoreVersion>
     <CoreFxVersion>4.4.0-*</CoreFxVersion>
+    <DepsRuntimeFrameworkVersion>2.0.0-preview3-25514-02</DepsRuntimeFrameworkVersion>
     <DotnetDebToolVersion>2.0.0-preview2-*</DotnetDebToolVersion>
     <InternalAspNetCoreSdkVersion>2.0.1-*</InternalAspNetCoreSdkVersion>
     <MoqVersion>4.7.49</MoqVersion>


### PR DESCRIPTION
Merging now to unblock. We need to keep this version in sync with korebuild and figure out what the actual problem is since pinning shouldn't be needed.