### PR TITLE
Use installed shared framework version during deps file generation

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -3,7 +3,6 @@
     <AspNetCoreIntegrationTestingVersion>0.4.0-*</AspNetCoreIntegrationTestingVersion>
     <AspNetCoreVersion>2.0.0-*</AspNetCoreVersion>
     <CoreFxVersion>4.4.0-*</CoreFxVersion>
-    <DepsRuntimeFrameworkVersion>2.0.0-preview3-25514-02</DepsRuntimeFrameworkVersion>
     <DotnetDebToolVersion>2.0.0-preview2-*</DotnetDebToolVersion>
     <InternalAspNetCoreSdkVersion>2.0.1-*</InternalAspNetCoreSdkVersion>
     <MoqVersion>4.7.49</MoqVersion>

--- a/build/repo.targets
+++ b/build/repo.targets
@@ -75,7 +75,7 @@
       Condition="Exists('$(DependencyBuildDirectory)')" />
   </Target>
 
-  <Target Name="BuildPackageCache" DependsOnTargets="UpdateNuGetConfig;AddDiaSymReaderToPath">
+  <Target Name="BuildPackageCache" DependsOnTargets="UpdateNuGetConfig;AddDiaSymReaderToPath;_ResolveCurrentSharedFrameworkVersion">
     <GetOSPlatform>
       <!-- Returns {Linux, macOS, Windows} -->
       <Output TaskParameter="PlatformName" PropertyName="OSPlatform" />
@@ -125,7 +125,7 @@
     <Exec Command="dotnet restore" WorkingDirectory="$(HostingStartupTemplatePath)" />
 
     <!--- MSBuild caches things if you run inproc so have to use Exec -->
-    <Exec Command="dotnet msbuild /t:&quot;Restore;Rebuild;CollectDeps&quot; $(HostingStartupTemplateFile) /p:&quot;DepsOutputPath=$(DepsOutputPath);HostingStartupPackageName=%(HostingStartupPackageReference.Identity);HostingStartupPackageVersion=%(Version)&quot;"/>
+    <Exec Command="dotnet msbuild /t:&quot;Restore;Rebuild;CollectDeps&quot; $(HostingStartupTemplateFile) /p:&quot;DepsOutputPath=$(DepsOutputPath);HostingStartupPackageName=%(HostingStartupPackageReference.Identity);HostingStartupPackageVersion=%(Version);RuntimeFrameworkVersion=$(SharedFrameworkVersion)&quot;"/>
 
     <ItemGroup>
       <PackageStoreManifestFiles Include="$(RuntimeStoreOutputPath)**\artifact.xml">
@@ -205,7 +205,10 @@
 
   <Target Name="_ResolveCurrentSharedFrameworkVersion">
     <!-- Parse framework version -->
-    <Exec Command="powershell.exe $(ToolsDir)GetSharedFrameworkVersion.ps1" ConsoleToMSBuild="true">
+    <Exec Command="powershell.exe $(ToolsDir)GetSharedFrameworkVersion.ps1" ConsoleToMSBuild="true" Condition="'$(OS)' == 'Windows_NT'">
+      <Output TaskParameter="ConsoleOutput" PropertyName="SharedFrameworkVersion" />
+    </Exec>
+    <Exec Command="bash $(ToolsDir)GetSharedFrameworkVersion.sh" ConsoleToMSBuild="true" Condition="'$(OS)' != 'Windows_NT'">
       <Output TaskParameter="ConsoleOutput" PropertyName="SharedFrameworkVersion" />
     </Exec>
   </Target>

--- a/tools/GetSharedFrameworkVersion.sh
+++ b/tools/GetSharedFrameworkVersion.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+dotnet --info | grep -i version | tail -1 | cut -f 2 -d ":" | tr -d ' '


### PR DESCRIPTION
This should fix the runtime versions for the deps files generated for the store