### PR TITLE
Remove NETStandardLibraryNETFrameworkVersion

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -8,7 +8,6 @@
     <JsonNetVersion>10.0.1</JsonNetVersion>
     <MoqVersion>4.7.49</MoqVersion>
     <NETStandardImplicitPackageVersion>2.0.0-*</NETStandardImplicitPackageVersion>
-    <NETStandardLibraryNETFrameworkVersion>2.0.0-*</NETStandardLibraryNETFrameworkVersion>
     <RuntimeFrameworkVersion Condition="'$(TargetFramework)'=='netcoreapp2.0'">2.0.0-*</RuntimeFrameworkVersion>
     <TestSdkVersion>15.3.0-*</TestSdkVersion>
     <XunitVersion>2.3.0-beta2-*</XunitVersion>


### PR DESCRIPTION
This property isn't needed anymore, but I'm mostly making this PR in the hopes that it refreshes TeamCity's git cache.