### PR TITLE
Wire up the IncludeScopes configuration option, closes #204

### DIFF
--- a/src/Microsoft.AspNetCore/WebHost.cs
+++ b/src/Microsoft.AspNetCore/WebHost.cs
@@ -179,8 +179,11 @@ namespace Microsoft.AspNetCore
                 })
                 .ConfigureLogging((hostingContext, logging) =>
                 {
-                    logging.AddConfiguration(hostingContext.Configuration.GetSection("Logging"));
-                    logging.AddConsole();
+                    var loggingConfig = hostingContext.Configuration.GetSection("Logging");
+                    logging.AddConfiguration(loggingConfig);
+                    logging.AddConsole(options =>
+                        options.IncludeScopes = loggingConfig.GetValue<bool>("IncludeScopes", false)
+                    );
                     logging.AddDebug();
                 })
                 .UseIISIntegration()


### PR DESCRIPTION
This option should affect the ConsoleLogger and isn't today