### PR TITLE
Use custom KoreBuild and dotnet-install if specified

### DIFF
--- a/build/repo.targets
+++ b/build/repo.targets
@@ -857,6 +857,7 @@
       --rm
       -v $(RepositoryRoot):$(DockerRootDirectory)
       -e DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true
+      -e KOREBUILD_SKIP_OLD_RUNTIME_INSTALL=true
       -e BuildNumber=$(BuildNumber)
       -e RUNTIMESTORE_TIMESTAMP_INSTALLERNAME=$(RuntimeStoreTimestampInstallerPackageName)
       -e RUNTIMESTORE_NOTIMESTAMP_INSTALLERNAME=$(RuntimeStoreNoTimestampInstallerPackageName)


### PR DESCRIPTION
This allows me to use a custom dotnet-install that skips the installation of the 1.0.5/1.1.2 runtime on certain platforms during the build on ubuntu.16.10.