### PR TITLE
Add kestrel config to CreateDefaultBuilder

### DIFF
--- a/samples/SampleApp/appsettings.json
+++ b/samples/SampleApp/appsettings.json
@@ -2,61 +2,47 @@
   "Kestrel": {
     "EndPoints": {
       "Http": {
-        "Address": "127.0.0.1",
-        "Port": 5000
-      },
+        "Url": "http://localhost:5005"
+      }
 
       // To enable HTTPS using a certificate file, set the path to a .pfx file in
       // the "Path" property below and configure the password in user secrets.
       // The "Password" property should be set in user secrets.
       //"HttpsInlineCertFile": {
-      //  "Address": "127.0.0.1",
-      //  "Port": 5001,
+      // "Url": "http://localhost:5005"
       //  "Certificate": {
-      //    "Source": "File",
-      //    "Path": "<path to .pfx file>"
+      //    "Path": "<path to .pfx file>",
+      //    "Password: "<cert password>"
       //  }
       //},
 
       //"HttpsInlineCertStore": {
-      //  "Address": "127.0.0.1",
-      //  "Port": 5002,
+      // "Url": "http://localhost:5005"
       //  "Certificate": {
-      //    "Source": "Store",
       //    "Subject": "",
-      //    "StoreName": "",
-      //    "StoreLocation": "",
+      //    "Store": "",
+      //    "Location": "",
       //    "AllowInvalid": "" // Set to "true" to allow invalid certificates (e.g. expired)
       //  }
       //},
 
-      // To enable this endpoint, set the path to a .pfx file in the "Path" property
-      // of the "TestCert" certificate defined under the "Certificates" section.
-      // Configure the password in user secrets.
-      //"HttpsCertFile": {
-      //  "Address": "127.0.0.1",
-      //  "Port": 5003,
-      //  "Certificate": "TestCert"
+      // This uses the cert defined under Certificates/Default or the development cert.
+      //"HttpsDefaultCert": {
+      // "Url": "http://localhost:5005"
       //}
-
-      //"HttpsCertStore": {
-      //  "Address": "127.0.0.1",
-      //  "Port": 5004,
-      //  "Certificate": "TestCertInStore"
-      //},
     }
   },
   "Certificates": {
-    //"TestCert": {
-    //  "Source": "File",
-    //  "Path": ""
+    //"Default": {
+    //  "Path": "<file>",
+    //  "Password": "<password>"
     //},
 
-    //"TestCertInStore": {
-    //  "Source": "Store",
+    // From cert store:
+    //"Default": {
     //  "Subject": "",
-    //  "StoreName": "",
-    //  "StoreLocation": "",
+    //  "Store": "",
+    //  "Location": "",
     //  "AllowInvalid": "" // Set to "true" to allow invalid certificates (e.g. expired certificates)
     //}
   }

--- a/src/Microsoft.AspNetCore/WebHost.cs
+++ b/src/Microsoft.AspNetCore/WebHost.cs
@@ -115,7 +115,7 @@ namespace Microsoft.AspNetCore
         /// </summary>
         /// <remarks>
         ///   The following defaults are applied to the returned <see cref="WebHostBuilder"/>:
-        ///     use Kestrel as the web server,
+        ///     use Kestrel as the web server and configure it using the application's configuration providers,
         ///     set the <see cref="IHostingEnvironment.ContentRootPath"/> to the result of <see cref="Directory.GetCurrentDirectory()"/>,
         ///     load <see cref="IConfiguration"/> from 'appsettings.json' and 'appsettings.[<see cref="IHostingEnvironment.EnvironmentName"/>].json',
         ///     load <see cref="IConfiguration"/> from User Secrets when <see cref="IHostingEnvironment.EnvironmentName"/> is 'Development' using the entry assembly,
@@ -133,7 +133,7 @@ namespace Microsoft.AspNetCore
         /// </summary>
         /// <remarks>
         ///   The following defaults are applied to the returned <see cref="WebHostBuilder"/>:
-        ///     use Kestrel as the web server,
+        ///     use Kestrel as the web server and configure it using the application's configuration providers,
         ///     set the <see cref="IHostingEnvironment.ContentRootPath"/> to the result of <see cref="Directory.GetCurrentDirectory()"/>,
         ///     load <see cref="IConfiguration"/> from 'appsettings.json' and 'appsettings.[<see cref="IHostingEnvironment.EnvironmentName"/>].json',
         ///     load <see cref="IConfiguration"/> from User Secrets when <see cref="IHostingEnvironment.EnvironmentName"/> is 'Development' using the entry assembly,
@@ -148,7 +148,10 @@ namespace Microsoft.AspNetCore
         public static IWebHostBuilder CreateDefaultBuilder(string[] args)
         {
             var builder = new WebHostBuilder()
-                .UseKestrel()
+                .UseKestrel((builderContext, options) =>
+                {
+                    options.Configure(builderContext.Configuration.GetSection("Kestrel"));
+                })
                 .UseContentRoot(Directory.GetCurrentDirectory())
                 .ConfigureAppConfiguration((hostingContext, config) =>
                 {
@@ -198,7 +201,7 @@ namespace Microsoft.AspNetCore
         /// </summary>
         /// <remarks>
         ///   The following defaults are applied to the returned <see cref="WebHostBuilder"/>:
-        ///     use Kestrel as the web server,
+        ///     use Kestrel as the web server and configure it using the application's configuration providers,
         ///     set the <see cref="IHostingEnvironment.ContentRootPath"/> to the result of <see cref="Directory.GetCurrentDirectory()"/>,
         ///     load <see cref="IConfiguration"/> from 'appsettings.json' and 'appsettings.[<see cref="IHostingEnvironment.EnvironmentName"/>].json',
         ///     load <see cref="IConfiguration"/> from User Secrets when <see cref="IHostingEnvironment.EnvironmentName"/> is 'Development' using the entry assembly,

--- a/test/Microsoft.AspNetCore.FunctionalTests/WebHostFunctionalTests.cs
+++ b/test/Microsoft.AspNetCore.FunctionalTests/WebHostFunctionalTests.cs
@@ -61,7 +61,8 @@ namespace Microsoft.AspNetCore.Tests
                 {
                     // Assert server is Kestrel
                     Assert.Equal("Kestrel", response.Headers.Server.ToString());
-
+                    // Set from default config
+                    Assert.Equal("http://localhost:5002/", deploymentResult.ApplicationBaseUri);
                     // The application name will be sent in response when all asserts succeed in the test app.
                     Assert.Equal(applicationName, responseText);
                 }

--- a/test/TestSites/CreateDefaultBuilderApp/appsettings.json
+++ b/test/TestSites/CreateDefaultBuilderApp/appsettings.json
@@ -1,3 +1,10 @@
 ﻿{
-  "settingsKey": "settingsValue"
+  "settingsKey": "settingsValue",
+  "Kestrel": {
+    "Endpoints": {
+      "HTTP": {
+        "Url": "http://localhost:5002"
+      }
+    }
+  }
 }


### PR DESCRIPTION
Kestrel now supports config, but it doesn't read any by default. CreateDefaultBuilder will specify the default location of the Kestrel config section. @DamianEdwards, @danroth27 asked if this config section should be namespaced as "Microsoft:Kestrel" or if a top level "Kestrel" section was ok?

I've also updated an old appsettings.json sample with the new config schema.

See https://github.com/aspnet/KestrelHttpServer/pull/2186