### PR TITLE
Force http in tests

### DIFF
--- a/test/Microsoft.AspNetCore.FunctionalTests/WebHostFunctionalTests.cs
+++ b/test/Microsoft.AspNetCore.FunctionalTests/WebHostFunctionalTests.cs
@@ -52,9 +52,7 @@ namespace Microsoft.AspNetCore.Tests
             var applicationName = "CreateDefaultBuilderApp";
             await ExecuteTestApp(applicationName, async (deploymentResult, logger) =>
             {
-                var handler = new HttpClientHandler() { ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator };
-                var client = new HttpClient(handler) { BaseAddress = new Uri(deploymentResult.ApplicationBaseUri) };
-                var response = await RetryHelper.RetryRequest(() => client.GetAsync(string.Empty), logger, deploymentResult.HostShutdownToken);
+                var response = await RetryHelper.RetryRequest(() => deploymentResult.HttpClient.GetAsync(string.Empty), logger, deploymentResult.HostShutdownToken);
 
                 var responseText = await response.Content.ReadAsStringAsync();
                 try
@@ -81,16 +79,15 @@ namespace Microsoft.AspNetCore.Tests
             var applicationName = "CreateDefaultBuilderOfTApp";
             await ExecuteTestApp(applicationName, async (deploymentResult, logger) =>
             {
-                var handler = new HttpClientHandler() { ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator };
-                var client = new HttpClient(handler) { BaseAddress = new Uri(deploymentResult.ApplicationBaseUri) };
-                var response = await RetryHelper.RetryRequest(() => client.GetAsync(string.Empty), logger, deploymentResult.HostShutdownToken);
+                var response = await RetryHelper.RetryRequest(() => deploymentResult.HttpClient.GetAsync(string.Empty), logger, deploymentResult.HostShutdownToken);
 
                 var responseText = await response.Content.ReadAsStringAsync();
                 try
                 {
                     // Assert server is Kestrel
                     Assert.Equal("Kestrel", response.Headers.Server.ToString());
-
+                    // Set from default config
+                    Assert.Equal("http://localhost:5002/", deploymentResult.ApplicationBaseUri);
                     // The application name will be sent in response when all asserts succeed in the test app.
                     Assert.Equal(applicationName, responseText);
                 }
@@ -111,9 +108,7 @@ namespace Microsoft.AspNetCore.Tests
             var applicationName = "DependencyInjectionApp";
             await ExecuteTestApp(applicationName, async (deploymentResult, logger) =>
             {
-                var handler = new HttpClientHandler() { ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator };
-                var client = new HttpClient(handler) { BaseAddress = new Uri(deploymentResult.ApplicationBaseUri) };
-                var response = await RetryHelper.RetryRequest(() => client.GetAsync(string.Empty), logger, deploymentResult.HostShutdownToken);
+                var response = await RetryHelper.RetryRequest(() => deploymentResult.HttpClient.GetAsync(string.Empty), logger, deploymentResult.HostShutdownToken);
                 var responseText = await response.Content.ReadAsStringAsync();
                 try
                 {

--- a/test/TestSites/CreateDefaultBuilderOfTApp/appsettings.json
+++ b/test/TestSites/CreateDefaultBuilderOfTApp/appsettings.json
@@ -1,3 +1,10 @@
 ﻿{
-  "settingsKey": "settingsValue"
+  "settingsKey": "settingsValue",
+  "Kestrel": {
+    "Endpoints": {
+      "HTTP": {
+        "Url": "http://localhost:5002"
+      }
+    }
+  }
 }

--- a/test/TestSites/DependencyInjectionApp/Program.cs
+++ b/test/TestSites/DependencyInjectionApp/Program.cs
@@ -22,6 +22,7 @@ namespace CreateDefaultBuilderApp
         static void Main(string[] args)
         {
             WebHost.CreateDefaultBuilder()
+                .UseUrls("http://localhost:5002")
                 .ConfigureServices((context, services) =>
                 {
                     services.AddSingleton(typeof(IService<>), typeof(Service<>));


### PR DESCRIPTION
The prior change did fix the invalid cert issue, but then some tests started failing only on net461 with an algorithm conflict. @javiercn you may want to check the default algorithms between a net461 client and a Core server.

Different fix: force these tests to use http.

Feel free to merge, I may be offline.