### PR TITLE
Fix tests failing after netcoreapp2.2 migration

### DIFF
--- a/test/TestSites/CreateDefaultBuilderApp/CreateDefaultBuilderApp.csproj
+++ b/test/TestSites/CreateDefaultBuilderApp/CreateDefaultBuilderApp.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <UserSecretsId>aspnetcore-CreateDefaultBuilder-20170424224131</UserSecretsId>
   </PropertyGroup>
 

--- a/test/TestSites/CreateDefaultBuilderOfTApp/CreateDefaultBuilderOfTApp.csproj
+++ b/test/TestSites/CreateDefaultBuilderOfTApp/CreateDefaultBuilderOfTApp.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <UserSecretsId>aspnetcore-CreateDefaultBuilderOfT-20170424224131</UserSecretsId>
   </PropertyGroup>
 

--- a/test/TestSites/DependencyInjectionApp/DependencyInjectionApp.csproj
+++ b/test/TestSites/DependencyInjectionApp/DependencyInjectionApp.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/TestSites/StartRequestDelegateUrlApp/StartRequestDelegateUrlApp.csproj
+++ b/test/TestSites/StartRequestDelegateUrlApp/StartRequestDelegateUrlApp.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/TestSites/StartRouteBuilderUrlApp/StartRouteBuilderUrlApp.csproj
+++ b/test/TestSites/StartRouteBuilderUrlApp/StartRouteBuilderUrlApp.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/TestSites/StartWithIApplicationBuilderUrlApp/StartWithIApplicationBuilderUrlApp.csproj
+++ b/test/TestSites/StartWithIApplicationBuilderUrlApp/StartWithIApplicationBuilderUrlApp.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
These test have been failing since the 2.2 migration last Tuesday. IntegrationTesting's default TFM was changed from 2.0 to 2.2.