### PR TITLE
Remove doc about unshipped default configuration

### DIFF
--- a/src/Microsoft.AspNetCore/WebHost.cs
+++ b/src/Microsoft.AspNetCore/WebHost.cs
@@ -122,16 +122,15 @@ namespace Microsoft.AspNetCore
         ///     load <see cref="IConfiguration"/> from 'appsettings.json' and 'appsettings.[<see cref="IHostingEnvironment.EnvironmentName"/>].json',
         ///     load <see cref="IConfiguration"/> from User Secrets when <see cref="IHostingEnvironment.EnvironmentName"/> is 'Development' using the entry assembly,
         ///     load <see cref="IConfiguration"/> from environment variables,
-        ///     configures the <see cref="ILoggerFactory"/> to log to the console and debug output,
-        ///     enables IIS integration,
-        ///     and enables the ability for frameworks to bind their options to their default configuration sections.
+        ///     configure the <see cref="ILoggerFactory"/> to log to the console and debug output,
+        ///     and enable IIS integration.
         /// </remarks>
         /// <returns>The initialized <see cref="IWebHostBuilder"/>.</returns>
         public static IWebHostBuilder CreateDefaultBuilder() =>
             CreateDefaultBuilder(args: null);
 
         /// <summary>
-        ///   Initializes a new instance of the <see cref="WebHostBuilder"/> class with pre-configured defaults.
+        /// Initializes a new instance of the <see cref="WebHostBuilder"/> class with pre-configured defaults.
         /// </summary>
         /// <remarks>
         ///   The following defaults are applied to the returned <see cref="WebHostBuilder"/>:
@@ -141,9 +140,8 @@ namespace Microsoft.AspNetCore
         ///     load <see cref="IConfiguration"/> from User Secrets when <see cref="IHostingEnvironment.EnvironmentName"/> is 'Development' using the entry assembly,
         ///     load <see cref="IConfiguration"/> from environment variables,
         ///     load <see cref="IConfiguration"/> from supplied command line args,
-        ///     configures the <see cref="ILoggerFactory"/> to log to the console and debug output,
-        ///     enables IIS integration,
-        ///     and enables the ability for frameworks to bind their options to their default configuration sections.
+        ///     configure the <see cref="ILoggerFactory"/> to log to the console and debug output,
+        ///     and enable IIS integration.
         /// </remarks>
         /// <param name="args">The command line args.</param>
         /// <returns>The initialized <see cref="IWebHostBuilder"/>.</returns>
@@ -232,9 +230,8 @@ namespace Microsoft.AspNetCore
         ///     load <see cref="IConfiguration"/> from User Secrets when <see cref="IHostingEnvironment.EnvironmentName"/> is 'Development' using the entry assembly,
         ///     load <see cref="IConfiguration"/> from environment variables,
         ///     load <see cref="IConfiguration"/> from supplied command line args,
-        ///     configures the <see cref="ILoggerFactory"/> to log to the console and debug output,
-        ///     enables IIS integration,
-        ///     enables the ability for frameworks to bind their options to their default configuration sections.
+        ///     configure the <see cref="ILoggerFactory"/> to log to the console and debug output,
+        ///     enable IIS integration.
         /// </remarks>
         /// <typeparam name ="TStartup">The type containing the startup methods for the application.</typeparam>
         /// <param name="args">The command line args.</param>


### PR DESCRIPTION
This removes the documentation about the default configuration capabilities in the default web host builder. The feature was originally introduced in 4b18cf52ae3c22c7124fd9cb35ae0253b390b28e and soon unshipped in c920c459537c21285b47b05f033a48363297e3dc. However, the documentation that was added with it never got removed.

Since this is visible on [docs.microsoft.com](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.webhost.createdefaultbuilder?view=aspnetcore-2.0), we should probably fix that before more people look for features that aren’t there.

/cc @ctolkien